### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ try {
 } catch (error) {
   console.error(`Unable to inspect module ${moduleName}.`);
   console.error(`Reason: ${error.message}`);
-  exit(1);
 }
 ```
 


### PR DESCRIPTION
Removed `exit(1);` line from index.js code snippet in Inspector Gadget section. This `exit(1);` doesn't appear in later snippets and I don't think it is needed because a success will trigger `try` which exits after console.log and a fail will be handled by `catch` which then console.log and exits.

Hope this makes sense & is helpful!